### PR TITLE
http2: RFC8441 extended connect protocol

### DIFF
--- a/http2/frame.go
+++ b/http2/frame.go
@@ -1478,7 +1478,7 @@ func (mh *MetaHeadersFrame) checkPseudos() error {
 	pf := mh.PseudoFields()
 	for i, hf := range pf {
 		switch hf.Name {
-		case ":method", ":path", ":scheme", ":authority":
+		case ":method", ":path", ":scheme", ":authority", ":protocol":
 			isRequest = true
 		case ":status":
 			isResponse = true
@@ -1486,7 +1486,7 @@ func (mh *MetaHeadersFrame) checkPseudos() error {
 			return pseudoHeaderError(hf.Name)
 		}
 		// Check for duplicates.
-		// This would be a bad algorithm, but N is 4.
+		// This would be a bad algorithm, but N is 5.
 		// And this doesn't allocate.
 		for _, hf2 := range pf[:i] {
 			if hf.Name == hf2.Name {

--- a/http2/http2.go
+++ b/http2/http2.go
@@ -139,6 +139,11 @@ func (s Setting) Valid() error {
 		if s.Val < 16384 || s.Val > 1<<24-1 {
 			return ConnectionError(ErrCodeProtocol)
 		}
+	// https://datatracker.ietf.org/doc/html/rfc8441#section-3
+	case SettingEnableConnectProtocol:
+		if s.Val != 1 && s.Val != 0 {
+			return ConnectionError(ErrCodeProtocol)
+		}
 	}
 	return nil
 }
@@ -148,21 +153,23 @@ func (s Setting) Valid() error {
 type SettingID uint16
 
 const (
-	SettingHeaderTableSize      SettingID = 0x1
-	SettingEnablePush           SettingID = 0x2
-	SettingMaxConcurrentStreams SettingID = 0x3
-	SettingInitialWindowSize    SettingID = 0x4
-	SettingMaxFrameSize         SettingID = 0x5
-	SettingMaxHeaderListSize    SettingID = 0x6
+	SettingHeaderTableSize       SettingID = 0x1
+	SettingEnablePush            SettingID = 0x2
+	SettingMaxConcurrentStreams  SettingID = 0x3
+	SettingInitialWindowSize     SettingID = 0x4
+	SettingMaxFrameSize          SettingID = 0x5
+	SettingMaxHeaderListSize     SettingID = 0x6
+	SettingEnableConnectProtocol SettingID = 0x8 // RFC 8441
 )
 
 var settingName = map[SettingID]string{
-	SettingHeaderTableSize:      "HEADER_TABLE_SIZE",
-	SettingEnablePush:           "ENABLE_PUSH",
-	SettingMaxConcurrentStreams: "MAX_CONCURRENT_STREAMS",
-	SettingInitialWindowSize:    "INITIAL_WINDOW_SIZE",
-	SettingMaxFrameSize:         "MAX_FRAME_SIZE",
-	SettingMaxHeaderListSize:    "MAX_HEADER_LIST_SIZE",
+	SettingHeaderTableSize:       "HEADER_TABLE_SIZE",
+	SettingEnablePush:            "ENABLE_PUSH",
+	SettingMaxConcurrentStreams:  "MAX_CONCURRENT_STREAMS",
+	SettingInitialWindowSize:     "INITIAL_WINDOW_SIZE",
+	SettingMaxFrameSize:          "MAX_FRAME_SIZE",
+	SettingMaxHeaderListSize:     "MAX_HEADER_LIST_SIZE",
+	SettingEnableConnectProtocol: "ENABLE_CONNECT_PROTOCOL",
 }
 
 func (s SettingID) String() string {

--- a/http2/http2_test.go
+++ b/http2/http2_test.go
@@ -44,6 +44,7 @@ func TestSettingString(t *testing.T) {
 	}{
 		{Setting{SettingMaxFrameSize, 123}, "[MAX_FRAME_SIZE = 123]"},
 		{Setting{1<<16 - 1, 123}, "[UNKNOWN_SETTING_65535 = 123]"},
+		{Setting{SettingEnableConnectProtocol, 1}, "[ENABLE_CONNECT_PROTOCOL = 1]"},
 	}
 	for i, tt := range tests {
 		got := fmt.Sprint(tt.s)


### PR DESCRIPTION
Support the Extended Connect Protocol defined by RFC 8441.

- Add a new pseudoheader :protocol
- New HTTP2 Server option "EnableConnectProtocol" to enable
the HTTP2 ENABLE_CONNECT_PROTOCOL setting.
- HTTP Request field "Proto", that was ignored from Clients, now
is used for setting the field ":protocol" on Connect requests

Change-Id: I1e4bf6a45bd667fa5e5388678bee0feac64641c1